### PR TITLE
Added -o (data-offset) as an allowed argument for make-bcache.

### DIFF
--- a/make-bcache.c
+++ b/make-bcache.c
@@ -366,7 +366,7 @@ int main(int argc, char **argv)
 	};
 
 	while ((c = getopt_long(argc, argv,
-				"-hCBU:w:b:",
+				"-hCBUo:w:b:",
 				opts, NULL)) != -1)
 		switch (c) {
 		case 'C':


### PR DESCRIPTION
Looks like I'm the first one using data-offset ? Looks like the -o option was never allowed on getopt_long.

If this was intentional, warn me please, as I normally will be using this soon.
