### PR TITLE
Small fixes to udev rules and initramfs hook

### DIFF
--- a/69-bcache.rules
+++ b/69-bcache.rules
@@ -3,6 +3,7 @@
 
 SUBSYSTEM!="block", GOTO="bcache_end"
 ACTION=="remove", GOTO="bcache_end"
+DRIVERS=="floppy", GOTO="bcache_end"
 ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="bcache_end"
 
 # blkid was run by the standard udev rules

--- a/69-bcache.rules
+++ b/69-bcache.rules
@@ -3,7 +3,6 @@
 
 SUBSYSTEM!="block", GOTO="bcache_end"
 ACTION=="remove", GOTO="bcache_end"
-DRIVERS=="floppy", GOTO="bcache_end"
 ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="bcache_end"
 
 # blkid was run by the standard udev rules
@@ -11,6 +10,8 @@ ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="bcache_end"
 ENV{ID_FS_TYPE}=="bcache", GOTO="bcache_backing_found"
 # It recognised something else; bail
 ENV{ID_FS_TYPE}=="?*", GOTO="bcache_backing_end"
+# Explicitly bail out for floppy drives (< util-linux-2.24)
+DRIVERS=="floppy", GOTO="bcache_end"
 
 # Backing devices: scan, symlink, register
 IMPORT{program}="probe-bcache -o udev $tempnode"

--- a/initramfs/hook
+++ b/initramfs/hook
@@ -16,7 +16,12 @@ esac
 
 . /usr/share/initramfs-tools/hook-functions
 
-cp -pt "${DESTDIR}/lib/udev/rules.d" /lib/udev/rules.d/69-bcache.rules
+if   [ -e /etc/udev/rules.d/69-bcache.rules ]; then
+    cp -pt "${DESTDIR}/lib/udev/rules.d" /etc/udev/rules.d/69-bcache.rules
+elif [ -e /lib/udev/rules.d/69-bcache.rules ]; then
+    cp -pt "${DESTDIR}/lib/udev/rules.d" /lib/udev/rules.d/69-bcache.rules
+fi
+
 copy_exec /lib/udev/bcache-register
 copy_exec /lib/udev/probe-bcache
 manual_add_modules bcache


### PR DESCRIPTION
These two patches sorted out the issues I had when installing bcache-tools on Ubuntu 14.04.

The test for floppy drives removed several pauses when booting the system. These would show up in dmesg as ~8 second pauses:

[    4.022378] random: nonblocking pool is initialized
[   13.284572] end_request: I/O error, dev fd0, sector 0
[   25.444523] end_request: I/O error, dev fd0, sector 0
[   25.444526] Buffer I/O error on device fd0, logical block 0
[   32.749886] EXT4-fs (sda1): mounted filesystem with ordered data
mode. Opts: (null)

The hook file modification allows any customised udev rule in /etc/udev/rules.d/ to be copied into the initramfs image.
