### PR TITLE
Replace bcache-register with native c code

### DIFF
--- a/69-bcache.rules
+++ b/69-bcache.rules
@@ -18,6 +18,7 @@ ENV{ID_FS_TYPE}!="bcache", GOTO="bcache_backing_end"
 ENV{ID_FS_UUID_ENC}=="?*", SYMLINK+="disk/by-uuid/$env{ID_FS_UUID_ENC}"
 
 LABEL="bcache_backing_found"
+RUN{builtin}+="kmod load bcache"
 RUN+="bcache-register $tempnode"
 LABEL="bcache_backing_end"
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DRACUTLIBDIR=/lib/dracut
 INSTALL=install
 CFLAGS+=-O2 -Wall -g
 
-all: make-bcache probe-bcache bcache-super-show
+all: make-bcache probe-bcache bcache-super-show bcache-register
 
 install: make-bcache probe-bcache bcache-super-show
 	$(INSTALL) -m0755 make-bcache bcache-super-show	$(DESTDIR)${PREFIX}/sbin/
@@ -29,3 +29,4 @@ probe-bcache: CFLAGS += `pkg-config --cflags uuid blkid`
 bcache-super-show: LDLIBS += `pkg-config --libs uuid`
 bcache-super-show: CFLAGS += -std=gnu99
 bcache-super-show: bcache.o
+bcache-register: bcache-register.o

--- a/bcache-register
+++ b/bcache-register
@@ -1,4 +1,0 @@
-#!/bin/sh
-/sbin/modprobe -qba bcache
-test -f /sys/fs/bcache/register_quiet && echo "$1" > /sys/fs/bcache/register_quiet
-

--- a/bcache-register.c
+++ b/bcache-register.c
@@ -1,0 +1,26 @@
+/*
+ * Author: Simon Gomizelj <simongmzlj@gmail.com>
+ *
+ * GPLv2
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+int main(int argc, char *argv[])
+{
+    int fd, i, rc = 0;
+
+    fd = open("/sys/fs/bcache/register_quiet", O_WRONLY);
+    if (fd < 0)
+        return 1;
+
+    for (i = 1; i < argc; ++i)
+        rc |= (dprintf(fd, "%s\n", argv[i]) < 0) ? 1 : 0;
+
+    close(fd);
+    return rc;
+}
+
+// vim: et:sts=4:sw=4:cino=(0


### PR DESCRIPTION
I run archlinux and this is my mkinitcpio.conf:

```
MODULES="bcache i915"
HOOKS="systemd autodetect modconf block bcache btrfs filesystems keyboard fsck"
```

I'm using the systemd hook instead of the base hook. This means my pre-boot environment is pure systemd, no busybox. This breaks bcache-register. In the pure systemd pre-boot environment, there is no busybox and there is no `/sbin/modprobe` (or any modprobe binary) anymore. Here is a replacement bcache-register binary that use libkmod to do the equivalent work.

My understanding is that systemd-as-early-boot is the direction upstream - both fedora and arch - wants to go, thus this prepares bcache for this eventuality.

Should you choose to adopt this, feel free to critique/request changes.
