### PR TITLE
Optional initrd (dracut) kernel cmdline parameters for bcache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CFLAGS+=-O2 -Wall -g
 
 all: make-bcache probe-bcache bcache-super-show bcache-register
 
-install: make-bcache probe-bcache bcache-super-show
+install: make-bcache probe-bcache bcache-super-show bcache-register
 	$(INSTALL) -m0755 make-bcache bcache-super-show	$(DESTDIR)${PREFIX}/sbin/
 	$(INSTALL) -m0755 probe-bcache bcache-register		$(DESTDIR)$(UDEVLIBDIR)/
 	$(INSTALL) -m0644 69-bcache.rules	$(DESTDIR)$(UDEVLIBDIR)/rules.d/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install: make-bcache probe-bcache bcache-super-show
 	$(INSTALL) -D -m0755 initramfs/hook	$(DESTDIR)/usr/share/initramfs-tools/hooks/bcache
 	$(INSTALL) -D -m0755 initcpio/install	$(DESTDIR)/usr/lib/initcpio/install/bcache
 	$(INSTALL) -D -m0755 dracut/module-setup.sh $(DESTDIR)$(DRACUTLIBDIR)/modules.d/90bcache/module-setup.sh
+	$(INSTALL) -D -m0755 dracut/parse-bcache.sh $(DESTDIR)$(DRACUTLIBDIR)/modules.d/90bcache/parse-bcache.sh
 #	$(INSTALL) -m0755 bcache-test $(DESTDIR)${PREFIX}/sbin/
 
 clean:

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -29,6 +29,7 @@ installkernel() {
 }
 
 install() {
-    inst_multiple ${udevdir}/probe-bcache ${udevdir}/bcache-register
+    inst_multiple ${udevdir}/bcache-register
     inst_rules 69-bcache.rules
+    inst_hook pre-mount 90 "$moddir/parse-bcache.sh"
 }

--- a/dracut/parse-bcache.sh
+++ b/dracut/parse-bcache.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+#
+# This allows some parameter passing to bcache during boot on the kernel
+# cmdline. Because the kernel cmdline is limited in size, the parameters
+# have short aliases.
+#
+declare -A parm_map
+
+parm_map[sco]="sequential_cutoff"
+parm_map[crdthr]="cache/congested_read_threshold_us"
+parm_map[cwrthr]="cache/congested_write_threshold_us"
+parm_map[sequential_cutoff]="sequential_cutoff"
+parm_map[congested_read_threshold_us]="cache/congested_read_threshold_us"
+parm_map[congested_write_threshold_us]="cache/congested_write_threshold_us"
+
+for i in /sys/block/bcache*/bcache
+do
+    [ -e "$i" ] || continue
+    DNAME=${i%/*}
+    DNAME=${DNAME##*/}
+    for j in `getarg "rd.$DNAME"`
+    do
+        ARGS="$j,"
+        while [ "$ARGS" != "" ]
+        do
+            ARG=${ARGS%%,*}
+            ARGS=${ARGS#*,}
+            [ "$ARG" == "" ] && continue
+
+            FN="${parm_map[${ARG%=*}]}"
+            VAL=${ARG#*=}
+            [ "$FN" == "" ] && continue
+
+            FILE="$i/$FN"
+            [ -e $FILE ] || continue
+            echo "$VAL" > "$FILE"
+        done
+    done
+done


### PR DESCRIPTION
This pull request adds support to pass bcache parameters to a (dracut generated) inital ramdisk during boot. This allows some tuning of the inital boot phase.

There's also a minor change in the makefile: it seems like bcache-register was missing from the install: dependencies.
