### PR TITLE
fixed linker error

### DIFF
--- a/bcache.c
+++ b/bcache.c
@@ -26,7 +26,7 @@
  * x^7 + x^4 + x + 1
 */
 
-static const uint64_t crc_table[256] = {
+const uint64_t crc_table[256] = {
 	0x0000000000000000ULL, 0x42F0E1EBA9EA3693ULL, 0x85E1C3D753D46D26ULL,
 	0xC711223CFA3E5BB5ULL, 0x493366450E42ECDFULL, 0x0BC387AEA7A8DA4CULL,
 	0xCCD2A5925D9681F9ULL, 0x8E224479F47CB76AULL, 0x9266CC8A1C85D9BEULL,
@@ -114,16 +114,3 @@ static const uint64_t crc_table[256] = {
 	0x5DEDC41A34BBEEB2ULL, 0x1F1D25F19D51D821ULL, 0xD80C07CD676F8394ULL,
 	0x9AFCE626CE85B507ULL
 };
-
-inline uint64_t crc64(const void *_data, size_t len)
-{
-	uint64_t crc = 0xFFFFFFFFFFFFFFFFULL;
-	const unsigned char *data = _data;
-
-	while (len--) {
-		int i = ((int) (crc >> 56) ^ *data++) & 0xFF;
-		crc = crc_table[i] ^ (crc << 8);
-	}
-
-	return crc ^ 0xFFFFFFFFFFFFFFFFULL;
-}

--- a/bcache.h
+++ b/bcache.h
@@ -115,7 +115,20 @@ BITMASK(BDEV_STATE,		struct cache_sb, flags, 61, 2);
 #define BDEV_STATE_DIRTY	2U
 #define BDEV_STATE_STALE	3U
 
-uint64_t crc64(const void *_data, size_t len);
+extern const uint64_t crc_table[];
+
+inline uint64_t crc64(const void *_data, size_t len)
+{
+        uint64_t crc = 0xFFFFFFFFFFFFFFFFULL;
+        const unsigned char *data = _data;
+
+        while (len--) {
+                int i = ((int) (crc >> 56) ^ *data++) & 0xFF;
+                crc = crc_table[i] ^ (crc << 8);
+        }
+
+        return crc ^ 0xFFFFFFFFFFFFFFFFULL;
+}
 
 #define node(i, j)		((void *) ((i)->d + (j)))
 #define end(i)			node(i, (i)->keys)

--- a/bcache.h
+++ b/bcache.h
@@ -117,7 +117,7 @@ BITMASK(BDEV_STATE,		struct cache_sb, flags, 61, 2);
 
 extern const uint64_t crc_table[];
 
-inline uint64_t crc64(const void *_data, size_t len)
+static inline uint64_t crc64(const void *_data, size_t len)
 {
         uint64_t crc = 0xFFFFFFFFFFFFFFFFULL;
         const unsigned char *data = _data;


### PR DESCRIPTION
gcc 5.1.1 rightfully complains about this:
`[rolf.fokkens@home07 bcache-tools-1.0.8.orig]$ make` 
`cc -O2 -Wall -g`pkg-config --cflags uuid blkid`-c -o bcache.o bcache.c`
`bcache.c:125:9: warning: ‘crc_table’ is static but used in inline function ‘crc64’ which is not static`
`crc = crc_table[i] ^ (crc << 8);`
`^`
`cc -O2 -Wall -g`pkg-config --cflags uuid blkid`make-bcache.c bcache.o`pkg-config --libs uuid blkid`-o make-bcache`
`/tmp/cchVVBrJ.o: In function`write_sb':`
`/tmp/bcache-tools-1.0.8.orig/make-bcache.c:277: undefined reference to `crc64'`
`collect2: error: ld returned 1 exit status`
`<builtin>: recipe for target 'make-bcache' failed`
`make: *** [make-bcache] Error 1`
`[rolf.fokkens@home07 bcache-tools-1.0.8.orig]$`
