### PR TITLE
moved from README to markdown format to easily include links; added l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # bcache
 These are the userspace tools required for bcache.
 
-`bcache` is a patch for the Linux kernel (developed in the kernel source tree) 
+`bcache` is integrated in the Linux kernel (developed in the kernel source tree)
 to use SSDs to cache other block
 devices. For more information, see http://bcache.evilpiepirate.org.
 Documentation for the run time interface is included in the kernel tree, in
-[Documentation/bcache.txt](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/bcache.txt).
+[Documentation/bcache.txt](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/bcache.txt). In order to use it you need
+to set the `CONFIG_BCACHE` setting in the `.config` file of the linux source
+build to `m` (to get built a loadable module) or `y` (to built `bcache` into
+the kernel).
 
 # usespace tools
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
+# bcache
 These are the userspace tools required for bcache.
 
-Bcache is a patch for the Linux kernel to use SSDs to cache other block
+`bcache` is a patch for the Linux kernel (developed in the kernel source tree) 
+to use SSDs to cache other block
 devices. For more information, see http://bcache.evilpiepirate.org.
 Documentation for the run time interface is included in the kernel tree, in
-Documentation/bcache.txt.
+[Documentation/bcache.txt](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/bcache.txt).
 
-Included:
+# usespace tools
 
-make-bcache
-Formats a block device for use with bcache. A device can be formatted for use
+## make-bcache
+Formats a block device for use with `bcache`. A device can be formatted for use
 as a cache or as a backing device (requires yet to be implemented kernel
 support). The most important option is for specifying the bucket size.
 Allocation is done in terms of buckets, and cache hits are counted per bucket;
@@ -17,13 +19,13 @@ performance. The bucket size is intended to be equal to the size of your SSD's
 erase blocks, which seems to be 128k-512k for most SSDs; feel free to
 experiment.
 
-bcache-super-show
+## bcache-super-show
 Prints the bcache superblock of a cache device or a backing device.
 
 
-Udev rules
-The first half of the rules do auto-assembly and add uuid symlinks
-to cache and backing devices.  If util-linux's libblkid is
+# udev rules
+The first half of the `udev` rules do auto-assembly and add uuid symlinks
+to cache and backing devices. If `util-linux`'s `libblkid` is
 sufficiently recent (2.24) the rules will take advantage of
 the fact that bcache has already been detected.  Otherwise
 they call a small probe-bcache program that imitates blkid.
@@ -31,8 +33,7 @@ they call a small probe-bcache program that imitates blkid.
 The second half of the rules add symlinks to cached devices,
 which are the devices created by the bcache kernel module.
 
+Note that `udev` is developed in the `systemd` source tree.
 
-Initramfs support
-Currently initramfs-tools, mkinitcpio and dracut are supported.
-
-
+# initramfs support
+Currently `initramfs-tools`, `mkinitcpio` and `dracut` are supported.


### PR DESCRIPTION
…inks to https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/bcache.txt (close #26); added markdown; added hint that udev is developed in systemd
